### PR TITLE
RabbitMQ 共识提供者实现连接支持amqp协议

### DIFF
--- a/source/consensus/consensus-mq/src/main/java/com/jd/blockchain/consensus/mq/factory/MsgQueueConfig.java
+++ b/source/consensus/consensus-mq/src/main/java/com/jd/blockchain/consensus/mq/factory/MsgQueueConfig.java
@@ -20,4 +20,6 @@ public final class MsgQueueConfig {
     public static final String NATS_PREFIX = "nats";
 
     public static final String RABBIT_PREFIX = "rabbit";
+
+    public static final String AMQP_PREFIX = "amqp";
 }

--- a/source/consensus/consensus-mq/src/main/java/com/jd/blockchain/consensus/mq/factory/MsgQueueFactory.java
+++ b/source/consensus/consensus-mq/src/main/java/com/jd/blockchain/consensus/mq/factory/MsgQueueFactory.java
@@ -12,8 +12,7 @@ package com.jd.blockchain.consensus.mq.factory;
 import com.jd.blockchain.consensus.mq.consumer.MsgQueueConsumer;
 import com.jd.blockchain.consensus.mq.producer.MsgQueueProducer;
 
-import static com.jd.blockchain.consensus.mq.factory.MsgQueueConfig.NATS_PREFIX;
-import static com.jd.blockchain.consensus.mq.factory.MsgQueueConfig.RABBIT_PREFIX;
+import static com.jd.blockchain.consensus.mq.factory.MsgQueueConfig.*;
 
 /**
  *
@@ -28,7 +27,7 @@ public class MsgQueueFactory {
         try {
             if (server.startsWith(NATS_PREFIX)) {
                 return NatsFactory.newProducer(server, topic);
-            } else if (server.startsWith(RABBIT_PREFIX)) {
+            } else if (server.startsWith(RABBIT_PREFIX) || server.startsWith(AMQP_PREFIX)) {
                 return RabbitFactory.newProducer(server, topic);
             }
         } catch (Exception e) {
@@ -41,7 +40,7 @@ public class MsgQueueFactory {
         try {
             if (server.startsWith(NATS_PREFIX)) {
                 return NatsFactory.newConsumer(server, topic);
-            } else if (server.startsWith(RABBIT_PREFIX)) {
+            } else if (server.startsWith(RABBIT_PREFIX) || server.startsWith(AMQP_PREFIX)) {
                 return RabbitFactory.newConsumer(server, topic);
             }
             return null;

--- a/source/consensus/consensus-mq/src/main/java/com/jd/blockchain/consensus/mq/factory/RabbitFactory.java
+++ b/source/consensus/consensus-mq/src/main/java/com/jd/blockchain/consensus/mq/factory/RabbitFactory.java
@@ -14,8 +14,10 @@ import com.jd.blockchain.consensus.mq.producer.MsgQueueProducer;
 import com.jd.blockchain.consensus.mq.producer.RabbitProducer;
 import com.rabbitmq.client.ConnectionFactory;
 
+import static com.jd.blockchain.consensus.mq.factory.MsgQueueConfig.*;
+
+
 /**
- *
  * @author shaozhuguang
  * @create 2018/11/5
  * @since 1.0.0
@@ -33,19 +35,23 @@ public class RabbitFactory {
 
     public static ConnectionFactory initConnectionFactory(String server) {
         ConnectionFactory factory = new ConnectionFactory();
-        // 解析server，生成host+port，默认格式：rabbit://localhost:5672
         try {
-            String[] hostAndPort = server.split("//")[1].split(":");
-            if (hostAndPort == null || hostAndPort.length == 0) {
-                factory.setHost("localhost");
-            } else if (hostAndPort.length == 1) {
-                factory.setHost(hostAndPort[0]);
+            //amqp协议默认格式：amqp://user:pass@host:10000/vhost ,更多内容参考：https://www.rabbitmq.com/uri-spec.html
+            if (server.startsWith(AMQP_PREFIX)) {
+                factory.setUri(server);
             } else {
-                factory.setHost(hostAndPort[0]);
-                factory.setPort(Integer.parseInt(hostAndPort[1]));
+                // 解析server，生成host+port，默认格式：rabbit://localhost:5672
+                String[] hostAndPort = server.split("//")[1].split(":");
+                if (hostAndPort.length == 1) {
+                    factory.setHost(hostAndPort[0]);
+                } else {
+                    factory.setHost(hostAndPort[0]);
+                    factory.setPort(Integer.parseInt(hostAndPort[1]));
+                }
             }
         } catch (Exception e) {
-            factory.setHost("localhost");
+            e.printStackTrace();
+            throw new IllegalStateException("Connection RabbitMQ failed！");
         }
         return factory;
     }

--- a/source/deployment/deployment-peer/src/main/resources/config/init/mq/mq.config
+++ b/source/deployment/deployment-peer/src/main/resources/config/init/mq/mq.config
@@ -1,4 +1,4 @@
-# MQ连接地址，格式：{MQ类型}://{IP}:{PORT}
+# MQ连接地址，格式：{MQ类型}://{IP}:{PORT}；RabbitMQ支持amqp协议连接，格式：amqp://user:pass@host:5672/vhost
 system.msg.queue.server=rabbit://127.0.0.1:5672
 
 # 当前账本交易发送队列主题（不同账本需不同主题）


### PR DESCRIPTION
rabbitMQ支持amqp协议，更方便接入已存在的带用户认证的mq服务。并兼容老的自定义的rabbit://协议。
amqp协议连接参考：https://www.rabbitmq.com/uri-spec.html